### PR TITLE
Embed Recent Talks section on talk page

### DIFF
--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -4,6 +4,7 @@ class TalksController < ApplicationController
 
   def index
     talks
+    recently_given
     @talk  = Talk.new
   end
 
@@ -19,6 +20,7 @@ class TalksController < ApplicationController
       redirect_to talks_url, notice: 'Talk was successfully created.'
     else
       talks
+      recently_given
       render action: "index"
     end
   end
@@ -40,6 +42,10 @@ class TalksController < ApplicationController
 
   def talks
     @talks ||= Talk.available
+  end
+
+  def recently_given
+    @recent_talks ||= Talk.recently_given
   end
 
   def verify_password

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -23,6 +23,10 @@ class Talk < ActiveRecord::Base
                   28.days.from_now)
   end
 
+  def self.recently_given
+    older.limit(6)
+  end
+
   def self.older
     by_kind.where("completed = ?", true)
   end

--- a/app/views/talks/index.html.erb
+++ b/app/views/talks/index.html.erb
@@ -10,8 +10,6 @@
       with us.
     </p>
 
-    <h2><%= link_to 'Past Talks Page', talks_past_path %></h2>
-
   </div>
   <div class="span8">
     <%= render 'form' %>
@@ -28,27 +26,48 @@
   </div>
 </div>
 
-<br />
+<div class="row-fluid">
+  <h2>Recent Talks</h2>
 
-<h1>Proposed Talks</h1>
+  <% @recent_talks.each_slice(3).each do |row| %>
+    <div class="row-fluid">
+      <% row.each do |talk| %>
+        <div class="proposed_talk span4">
+          <h4><%= link_to talk.title, talk %></h4> <%= talk.scheduled_date %>
+          <div><%= indefinite_Articlerize talk.kind %> talk given by <%= talk.presenter %></div>
+          <p class="description">
+            <%= talk.description.truncate(200, separator: ' ', omission: "...") unless talk.description.nil? %>
+            <%= if talk.description.length > 200 then link_to("read more", talk) end unless talk.description.nil? %>
+          </p>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
 
-<% @talks.each_slice(3).each do |row| %>
-  <div class="row-fluid">
-    <% row.each do |talk| %>
-      <div class="proposed_talk span4">
-        <h4><%= link_to talk.title, talk %></h4>
-        <% if talk.event %>
-          <h5>Scheduled <%= talk.event.date %></h5>
-        <% end %>
+  <%= link_to 'More Talks', talks_past_path, {:style => 'font-size 16px; font-weight: bold'} -%>
+</div>
 
-        <div><%= indefinite_Articlerize talk.kind %> talk proposed by <%= talk.presenter %></div>
-        <p class="description">
-          <%= talk.description.truncate(200, separator: ' ', omission: "...") unless talk.description.nil? %>
-          <%= if talk.description.length > 200 then link_to("read more", talk) end unless talk.description.nil? %>
-        </p>
-      </div>
-    <% end %>
-  </div>
-<% end %>
+<div class="row-fluid">
+  <h2>Proposed Talks</h2>
 
-<%= link_to 'Suggest a Topic For a Talk', suggestions_path, {:style => 'font-size 16px; font-weight: bold'} -%>
+  <% @talks.each_slice(3).each do |row| %>
+    <div class="row-fluid">
+      <% row.each do |talk| %>
+        <div class="proposed_talk span4">
+          <h4><%= link_to talk.title, talk %></h4>
+          <% if talk.event %>
+            <h5>Scheduled <%= talk.event.date %></h5>
+          <% end %>
+
+          <div><%= indefinite_Articlerize talk.kind %> talk proposed by <%= talk.presenter %></div>
+          <p class="description">
+            <%= talk.description.truncate(200, separator: ' ', omission: "...") unless talk.description.nil? %>
+            <%= if talk.description.length > 200 then link_to("read more", talk) end unless talk.description.nil? %>
+          </p>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+  
+  <%= link_to 'Suggest a Topic For a Talk', suggestions_path, {:style => 'font-size 16px; font-weight: bold'} -%>
+</div>


### PR DESCRIPTION
Adds a section entitled “Recent Talks” that embeds no more than 6
completed talks, in reverse-chronological order. This provides context
to the submitted as to what sort of talks Seattle.rb hosts